### PR TITLE
[federatorai-operator] nks-system now deploy Prometheus by default, handle the conflict with federator.ai.

### DIFF
--- a/stable/federatorai-operator/Chart.yaml
+++ b/stable/federatorai-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 4.2.280
+appVersion: 4.2.286
 description: Federator.ai is the brain of resource orchestration for Kubernetes. It
   is a prediction engine that foresees future resource usage of your Kubernetes cluster
   from the cloud layer down to the pod level. We use machine learning technology to

--- a/stable/federatorai-operator/charts/prometheus-operator/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/stable/federatorai-operator/charts/prometheus-operator/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -33,22 +33,22 @@ spec:
           args:
             - --path.procfs=/host/proc
             - --path.sysfs=/host/sys
-            - --web.listen-address=0.0.0.0:{{ .Values.service.port }}
+            - --web.listen-address=0.0.0.0:{{ .Values.service.pdsTargetPort }}
 {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 12 }}
 {{- end }}
           ports:
             - name: metrics
-              containerPort: {{ .Values.service.targetPort }}
+              containerPort: {{ .Values.service.pdsTargetPort }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /
-              port: {{ .Values.service.port }}
+              port: {{ .Values.service.pdsTargetPort }}
           readinessProbe:
             httpGet:
               path: /
-              port: {{ .Values.service.port }}
+              port: {{ .Values.service.pdsTargetPort }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:

--- a/stable/federatorai-operator/charts/prometheus-operator/charts/prometheus-node-exporter/templates/service.yaml
+++ b/stable/federatorai-operator/charts/prometheus-operator/charts/prometheus-node-exporter/templates/service.yaml
@@ -14,7 +14,7 @@ spec:
     {{- if ( and (eq .Values.service.type "NodePort" ) (not (empty .Values.service.nodePort)) ) }}
       nodePort: {{ .Values.service.nodePort }}
     {{- end }}
-      targetPort: {{ .Values.service.targetPort }}
+      targetPort: {{ .Values.service.pdsTargetPort }}
       protocol: TCP
       name: metrics
   selector:

--- a/stable/federatorai-operator/charts/prometheus-operator/charts/prometheus-node-exporter/values.yaml
+++ b/stable/federatorai-operator/charts/prometheus-operator/charts/prometheus-node-exporter/values.yaml
@@ -9,7 +9,7 @@ image:
 service:
   type: ClusterIP
   port: 9100
-  targetPort: 9100
+  pdsTargetPort: 9101
   nodePort:
   annotations:
     prometheus.io/scrape: "true"

--- a/stable/federatorai-operator/charts/prometheus-operator/values.yaml
+++ b/stable/federatorai-operator/charts/prometheus-operator/values.yaml
@@ -71,7 +71,7 @@ alertmanager:
 
   ## Deploy alertmanager
   ##
-  enabled: true
+  enabled: false
 
   ## Service account for Alertmanager to use.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -319,7 +319,7 @@ alertmanager:
 ## Using default values from https://github.com/helm/charts/blob/master/stable/grafana/values.yaml
 ##
 grafana:
-  enabled: true
+  enabled: false
 
   ## Deploy default dashboards.
   ##

--- a/stable/federatorai-operator/values.yaml
+++ b/stable/federatorai-operator/values.yaml
@@ -15,7 +15,7 @@ image:
 alameda:
   version: stable
   ## NKS trusted-helm prometheus exposes as http://pk8s.monitoring.svc:9090
-  prometheusService: http://pk8s.monitoring.svc:9090
+  # prometheusService: http://pk8s.monitoring.svc:9090
   ## OpenShift prometheus exposes as https://prometheus-k8s.openshift-monitoring.svc:9091
   # prometheusService: https://prometheus-k8s.openshift-monitoring:9091
   ## K8S  prometheus exposes as http://monitoring-prometheus-oper-prometheus.<namespace>.svc:9090
@@ -23,9 +23,10 @@ alameda:
 
 prometheus:
   ## Deploy built-in prometheus chart
+  ## if this value is false, you need to specify the above alameda.prometheusService value
   enabled: true
 
 grafana:
-  ## Specify the nodePort value between 30000-32767 for the Grafana
+  ## Specify the nodePort value between 30000-32767 for the Grafana Server
   ## Comment out the following line to disable nodePort service
   nodePort: 31010


### PR DESCRIPTION
The deployed cluster now install Prometheus in nks-system namespace by default which has conflict with federatorai-operator . This commit handles the conflict. 